### PR TITLE
fix: rename `useCollection*` hooks to `useQuery*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ This library consists of 6 modules with many hooks:
     -   [`useDocumentData`](#useDocumentData)
     -   [`useDocumentDataOnce`](#useDocumentataOnce)
     -   [`useDocumentOnce`](#useDocumentOnce)
+    -   [`useQuery`](#useQuery)
+    -   [`useQueryData`](#useQueryData)
+    -   [`useQueryDataOnce`](#useQueryDataOnce)
+    -   [`useQueryOnce`](#useQueryOnce)
 -   [`messaging`](#Messaging)
     -   [`useMessagingToken`](#useMessagingToken)
 -   [`storage`](#Storage)
@@ -244,79 +248,19 @@ import { ... } from 'react-firehooks/firestore';
 
 #### useCollection
 
-Returns and updates a QuerySnapshot of a Firestore Query
-
-```javascript
-const [querySnap, loading, error] = useCollection(query, options);
-```
-
-Params:
-
--   `query`: Firestore query that will be subscribed to
--   `options`: Options to configure the subscription
-
-Returns:
-
--   `value`: QuerySnapshot; `undefined` if query is currently being fetched, or an error occurred
--   `loading`: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
--   `error`: `undefined` if no error occurred
+Deprecated. Identical to [`useQuery`](#useQuery)
 
 #### useCollectionData
 
-Returns and updates a the document data of a Firestore Query
-
-```javascript
-const [data, loading, error] = useCollectionData(query, options);
-```
-
-Params:
-
--   `query`: Firestore query that will be subscribed to
--   `options`: Options to configure the subscription
-
-Returns:
-
--   `value`: Query data; `undefined` if query is currently being fetched, or an error occurred
--   `loading`: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
--   `error`: `undefined` if no error occurred
+Deprecated. Identical to [`useQueryData`](#useQueryData)
 
 #### useCollectionDataOnce
 
-Returns the data of a Firestore Query. Does not update the data once initially fetched
-
-```javascript
-const [data, loading, error] = useCollectionDataOnce(query, options);
-```
-
-Params:
-
--   `query`: Firestore query that will be fetched
--   `options`: Options to configure how the query is fetched
-
-Returns:
-
--   `value`: Query data; `undefined` if query is currently being fetched, or an error occurred
--   `loading`: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
--   `error`: `undefined` if no error occurred
+Deprecated. Identical to [`useQueryDataOnce`](#useQueryDataOnce)
 
 #### useCollectionOnce
 
-Returns the QuerySnapshot of a Firestore Query. Does not update the QuerySnapshot once initially fetched
-
-```javascript
-const [querySnap, loading, error] = useCollectionOnce(query, options);
-```
-
-Params:
-
--   `query`: Firestore query that will be fetched
--   `options`: Options to configure how the query is fetched
-
-Returns:
-
--   `value`: QuerySnapshot; `undefined` if query is currently being fetched, or an error occurred
--   `loading`: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
--   `error`: `undefined` if no error occurred
+Deprecated. Identical to [`useQueryOnce`](#useQueryOnce)
 
 #### useCountFromServer
 
@@ -412,6 +356,82 @@ Returns:
 
 -   `value`: DocumentSnapshot; `undefined` if document does not exist, is currently being fetched, or an error occurred
 -   `loading`: `true` while fetching the document; `false` if the document was fetched successfully or an error occurred
+-   `error`: `undefined` if no error occurred
+
+#### useQuery
+
+Returns and updates a QuerySnapshot of a Firestore Query
+
+```javascript
+const [querySnap, loading, error] = useQuery(query, options);
+```
+
+Params:
+
+-   `query`: Firestore query that will be subscribed to
+-   `options`: Options to configure the subscription
+
+Returns:
+
+-   `value`: QuerySnapshot; `undefined` if query is currently being fetched, or an error occurred
+-   `loading`: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
+-   `error`: `undefined` if no error occurred
+
+#### useQueryData
+
+Returns and updates a the document data of a Firestore Query
+
+```javascript
+const [data, loading, error] = useQueryData(query, options);
+```
+
+Params:
+
+-   `query`: Firestore query that will be subscribed to
+-   `options`: Options to configure the subscription
+
+Returns:
+
+-   `value`: Query data; `undefined` if query is currently being fetched, or an error occurred
+-   `loading`: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
+-   `error`: `undefined` if no error occurred
+
+#### useQueryDataOnce
+
+Returns the data of a Firestore Query. Does not update the data once initially fetched
+
+```javascript
+const [data, loading, error] = useQueryDataOnce(query, options);
+```
+
+Params:
+
+-   `query`: Firestore query that will be fetched
+-   `options`: Options to configure how the query is fetched
+
+Returns:
+
+-   `value`: Query data; `undefined` if query is currently being fetched, or an error occurred
+-   `loading`: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
+-   `error`: `undefined` if no error occurred
+
+#### useQueryOnce
+
+Returns the QuerySnapshot of a Firestore Query. Does not update the QuerySnapshot once initially fetched
+
+```javascript
+const [querySnap, loading, error] = useQueryOnce(query, options);
+```
+
+Params:
+
+-   `query`: Firestore query that will be fetched
+-   `options`: Options to configure how the query is fetched
+
+Returns:
+
+-   `value`: QuerySnapshot; `undefined` if query is currently being fetched, or an error occurred
+-   `loading`: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
 -   `error`: `undefined` if no error occurred
 
 ### Messaging

--- a/src/firestore/index.ts
+++ b/src/firestore/index.ts
@@ -8,3 +8,7 @@ export * from "./useDocument.js";
 export * from "./useDocumentData.js";
 export * from "./useDocumentDataOnce.js";
 export * from "./useDocumentOnce.js";
+export * from "./useQuery.js";
+export * from "./useQueryData.js";
+export * from "./useQueryDataOnce.js";
+export * from "./useQueryOnce.js";

--- a/src/firestore/useCollection.ts
+++ b/src/firestore/useCollection.ts
@@ -1,47 +1,5 @@
-import { DocumentData, FirestoreError, onSnapshot, Query, QuerySnapshot, SnapshotListenOptions } from "firebase/firestore";
-import { useCallback } from "react";
-import { ValueHookResult } from "../common/types.js";
-import { useListen, UseListenOnChange } from "../internal/useListen.js";
-import { LoadingState } from "../internal/useLoadingValue.js";
-import { isQueryEqual } from "./internal.js";
-
-export type UseCollectionResult<Value extends DocumentData = DocumentData> = ValueHookResult<
-    QuerySnapshot<Value>,
-    FirestoreError
->;
-
-/**
- * Options to configure the subscription
- */
-export interface UseCollectionOptions {
-    snapshotListenOptions?: SnapshotListenOptions;
-}
-
-/**
- * Returns and updates a QuerySnapshot of a Firestore Query
- *
- * @template Value Type of the collection data
- * @param {Query<Value> | undefined | null} query Firestore query that will be subscribed to
- * @param {?UseCollectionOptions} options Options to configure the subscription
- * @returns {UseCollectionResult<Value>} QuerySnapshot, loading, and error
- * * value: QuerySnapshot; `undefined` if query is currently being fetched, or an error occurred
- * * loading: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
- * * error: `undefined` if no error occurred
- */
-export function useCollection<Value extends DocumentData = DocumentData>(
-    query: Query<Value> | undefined | null,
-    options?: UseCollectionOptions
-): UseCollectionResult<Value> {
-    const { snapshotListenOptions = {} } = options ?? {};
-
-    const onChange: UseListenOnChange<QuerySnapshot<Value>, FirestoreError, Query<Value>> = useCallback(
-        (stableQuery, next, error) =>
-            onSnapshot<Value>(stableQuery, snapshotListenOptions, {
-                next,
-                error,
-            }),
-        []
-    );
-
-    return useListen(query ?? undefined, onChange, isQueryEqual, LoadingState);
-}
+export {
+    useQuery as useCollection,
+    UseQueryOptions as UseCollectionOptions,
+    UseQueryResult as UseCollectionResult,
+} from "./useQuery.js";

--- a/src/firestore/useCollectionData.ts
+++ b/src/firestore/useCollectionData.ts
@@ -1,47 +1,5 @@
-import { DocumentData, FirestoreError, onSnapshot, Query, SnapshotListenOptions, SnapshotOptions } from "firebase/firestore";
-import { useCallback } from "react";
-import { ValueHookResult } from "../common/types.js";
-import { useListen, UseListenOnChange } from "../internal/useListen.js";
-import { LoadingState } from "../internal/useLoadingValue.js";
-import { isQueryEqual } from "./internal.js";
-
-export type UseCollectionDataResult<Value extends DocumentData = DocumentData> = ValueHookResult<Value[], FirestoreError>;
-
-/**
- * Options to configure the subscription
- */
-export interface UseCollectionDataOptions<Value extends DocumentData = DocumentData> {
-    snapshotListenOptions?: SnapshotListenOptions;
-    snapshotOptions?: SnapshotOptions;
-    initialValue?: Value[];
-}
-
-/**
- * Returns and updates a the document data of a Firestore Query
- *
- * @template Value Type of the collection data
- * @param {Query<Value> | undefined | null} query Firestore query that will be subscribed to
- * @param {?UseCollectionDataOptions} options Options to configure the subscription
- * * `initialValue`: Value that is returned while the query is being fetched.
- * @returns {UseCollectionDataResult<Value>} Query data, loading state, and error
- * * value: Query data; `undefined` if query is currently being fetched, or an error occurred
- * * loading: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
- * * error: `undefined` if no error occurred
- */
-export function useCollectionData<Value extends DocumentData = DocumentData>(
-    query: Query<Value> | undefined | null,
-    options?: UseCollectionDataOptions<Value>
-): UseCollectionDataResult<Value> {
-    const { snapshotListenOptions = {}, snapshotOptions = {} } = options ?? {};
-
-    const onChange: UseListenOnChange<Value[], FirestoreError, Query<Value>> = useCallback(
-        (stableQuery, next, error) =>
-            onSnapshot<Value>(stableQuery, snapshotListenOptions, {
-                next: (snap) => next(snap.docs.map((doc) => doc.data(snapshotOptions))),
-                error,
-            }),
-        []
-    );
-
-    return useListen(query ?? undefined, onChange, isQueryEqual, options?.initialValue ?? LoadingState);
-}
+export {
+    useQueryData as useCollectionData,
+    UseQueryDataOptions as UseCollectionDataOptions,
+    UseQueryDataResult as UseCollectionDataResult,
+} from "./useQueryData.js";

--- a/src/firestore/useCollectionDataOnce.ts
+++ b/src/firestore/useCollectionDataOnce.ts
@@ -1,43 +1,5 @@
-import { DocumentData, FirestoreError, Query, SnapshotOptions } from "firebase/firestore";
-import { useCallback } from "react";
-import type { ValueHookResult } from "../common/types.js";
-import { useOnce } from "../internal/useOnce.js";
-import { getDocsFromSource, isQueryEqual } from "./internal.js";
-import type { Source } from "./types.js";
-
-export type UseCollectionDataOnceResult<Value extends DocumentData = DocumentData> = ValueHookResult<
-    Value[],
-    FirestoreError
->;
-
-/**
- * Options to configure the subscription
- */
-export interface UseCollectionDataOnceOptions {
-    source?: Source;
-    snapshotOptions?: SnapshotOptions;
-}
-
-/**
- * Returns the data of a Firestore Query. Does not update the data once initially fetched
- *
- * @template Value Type of the collection data
- * @param {Query<Value> | undefined | null} query Firestore query that will be fetched
- * @param {?UseCollectionDataOnceOptions} options Options to configure how the query is fetched
- * @returns {UseCollectionDataOnceResult<Value>} Query data, loading state, and error
- * * value: Query data; `undefined` if query is currently being fetched, or an error occurred
- * * loading: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
- * * error: `undefined` if no error occurred
- */
-export function useCollectionDataOnce<Value extends DocumentData = DocumentData>(
-    query: Query<Value> | undefined | null,
-    options?: UseCollectionDataOnceOptions
-): UseCollectionDataOnceResult<Value> {
-    const { source = "default", snapshotOptions = {} } = options ?? {};
-
-    const getData = useCallback(async (stableQuery: Query<Value>) => {
-        const snap = await getDocsFromSource(stableQuery, source);
-        return snap.docs.map((doc) => doc.data(snapshotOptions));
-    }, []);
-    return useOnce(query ?? undefined, getData, isQueryEqual);
-}
+export {
+    useQueryDataOnce as useCollectionDataOnce,
+    UseQueryDataOnceOptions as UseCollectionDataOnceOptions,
+    UseQueryDataOnceResult as UseCollectionDataOnceResult,
+} from "./useQueryDataOnce.js";

--- a/src/firestore/useCollectionOnce.ts
+++ b/src/firestore/useCollectionOnce.ts
@@ -1,39 +1,5 @@
-import { DocumentData, FirestoreError, Query, QuerySnapshot } from "firebase/firestore";
-import { useCallback } from "react";
-import type { ValueHookResult } from "../common/types.js";
-import { useOnce } from "../internal/useOnce.js";
-import { getDocsFromSource, isQueryEqual } from "./internal.js";
-import type { Source } from "./types.js";
-
-export type UseCollectionOnceResult<Value extends DocumentData = DocumentData> = ValueHookResult<
-    QuerySnapshot<Value>,
-    FirestoreError
->;
-
-/**
- * Options to configure how the query is fetched
- */
-export interface UseCollectionOnceOptions {
-    source?: Source;
-}
-
-/**
- * Returns the QuerySnapshot of a Firestore Query. Does not update the QuerySnapshot once initially fetched
- *
- * @template Value Type of the collection data
- * @param {Query<Value> | undefined | null} query Firestore query that will be fetched
- * @param {?UseCollectionOnceOptions} options Options to configure how the query is fetched
- * @returns {UseCollectionOnceResult<Value>} QuerySnapshot, loading state, and error
- * * value: QuerySnapshot; `undefined` if query is currently being fetched, or an error occurred
- * * loading: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
- * * error: `undefined` if no error occurred
- */
-export function useCollectionOnce<Value extends DocumentData = DocumentData>(
-    query: Query<Value> | undefined | null,
-    options?: UseCollectionOnceOptions
-): UseCollectionOnceResult<Value> {
-    const { source = "default" } = options ?? {};
-
-    const getData = useCallback(async (stableQuery: Query<Value>) => getDocsFromSource(stableQuery, source), []);
-    return useOnce(query ?? undefined, getData, isQueryEqual);
-}
+export {
+    useQueryOnce as useCollectionOnce,
+    UseQueryOnceOptions as UseCollectionOnceOptions,
+    UseQueryOnceResult as UseCollectionOnceResult,
+} from "./useQueryOnce.js";

--- a/src/firestore/useQuery.ts
+++ b/src/firestore/useQuery.ts
@@ -1,0 +1,47 @@
+import { DocumentData, FirestoreError, onSnapshot, Query, QuerySnapshot, SnapshotListenOptions } from "firebase/firestore";
+import { useCallback } from "react";
+import { ValueHookResult } from "../common/types.js";
+import { useListen, UseListenOnChange } from "../internal/useListen.js";
+import { LoadingState } from "../internal/useLoadingValue.js";
+import { isQueryEqual } from "./internal.js";
+
+export type UseQueryResult<Value extends DocumentData = DocumentData> = ValueHookResult<
+    QuerySnapshot<Value>,
+    FirestoreError
+>;
+
+/**
+ * Options to configure the subscription
+ */
+export interface UseQueryOptions {
+    snapshotListenOptions?: SnapshotListenOptions;
+}
+
+/**
+ * Returns and updates a QuerySnapshot of a Firestore Query
+ *
+ * @template Value Type of the collection data
+ * @param {Query<Value> | undefined | null} query Firestore query that will be subscribed to
+ * @param {?UseQueryOptions} options Options to configure the subscription
+ * @returns {UseQueryResult<Value>} QuerySnapshot, loading, and error
+ * * value: QuerySnapshot; `undefined` if query is currently being fetched, or an error occurred
+ * * loading: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
+ * * error: `undefined` if no error occurred
+ */
+export function useQuery<Value extends DocumentData = DocumentData>(
+    query: Query<Value> | undefined | null,
+    options?: UseQueryOptions
+): UseQueryResult<Value> {
+    const { snapshotListenOptions = {} } = options ?? {};
+
+    const onChange: UseListenOnChange<QuerySnapshot<Value>, FirestoreError, Query<Value>> = useCallback(
+        (stableQuery, next, error) =>
+            onSnapshot<Value>(stableQuery, snapshotListenOptions, {
+                next,
+                error,
+            }),
+        []
+    );
+
+    return useListen(query ?? undefined, onChange, isQueryEqual, LoadingState);
+}

--- a/src/firestore/useQueryData.ts
+++ b/src/firestore/useQueryData.ts
@@ -1,0 +1,47 @@
+import { DocumentData, FirestoreError, onSnapshot, Query, SnapshotListenOptions, SnapshotOptions } from "firebase/firestore";
+import { useCallback } from "react";
+import { ValueHookResult } from "../common/types.js";
+import { useListen, UseListenOnChange } from "../internal/useListen.js";
+import { LoadingState } from "../internal/useLoadingValue.js";
+import { isQueryEqual } from "./internal.js";
+
+export type UseQueryDataResult<Value extends DocumentData = DocumentData> = ValueHookResult<Value[], FirestoreError>;
+
+/**
+ * Options to configure the subscription
+ */
+export interface UseQueryDataOptions<Value extends DocumentData = DocumentData> {
+    snapshotListenOptions?: SnapshotListenOptions;
+    snapshotOptions?: SnapshotOptions;
+    initialValue?: Value[];
+}
+
+/**
+ * Returns and updates a the document data of a Firestore Query
+ *
+ * @template Value Type of the collection data
+ * @param {Query<Value> | undefined | null} query Firestore query that will be subscribed to
+ * @param {?UseQueryDataOptions} options Options to configure the subscription
+ * * `initialValue`: Value that is returned while the query is being fetched.
+ * @returns {UseQueryDataResult<Value>} Query data, loading state, and error
+ * * value: Query data; `undefined` if query is currently being fetched, or an error occurred
+ * * loading: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
+ * * error: `undefined` if no error occurred
+ */
+export function useQueryData<Value extends DocumentData = DocumentData>(
+    query: Query<Value> | undefined | null,
+    options?: UseQueryDataOptions<Value>
+): UseQueryDataResult<Value> {
+    const { snapshotListenOptions = {}, snapshotOptions = {} } = options ?? {};
+
+    const onChange: UseListenOnChange<Value[], FirestoreError, Query<Value>> = useCallback(
+        (stableQuery, next, error) =>
+            onSnapshot<Value>(stableQuery, snapshotListenOptions, {
+                next: (snap) => next(snap.docs.map((doc) => doc.data(snapshotOptions))),
+                error,
+            }),
+        []
+    );
+
+    return useListen(query ?? undefined, onChange, isQueryEqual, options?.initialValue ?? LoadingState);
+}

--- a/src/firestore/useQueryDataOnce.ts
+++ b/src/firestore/useQueryDataOnce.ts
@@ -1,0 +1,40 @@
+import { DocumentData, FirestoreError, Query, SnapshotOptions } from "firebase/firestore";
+import { useCallback } from "react";
+import type { ValueHookResult } from "../common/types.js";
+import { useOnce } from "../internal/useOnce.js";
+import { getDocsFromSource, isQueryEqual } from "./internal.js";
+import type { Source } from "./types.js";
+
+export type UseQueryDataOnceResult<Value extends DocumentData = DocumentData> = ValueHookResult<Value[], FirestoreError>;
+
+/**
+ * Options to configure the subscription
+ */
+export interface UseQueryDataOnceOptions {
+    source?: Source;
+    snapshotOptions?: SnapshotOptions;
+}
+
+/**
+ * Returns the data of a Firestore Query. Does not update the data once initially fetched
+ *
+ * @template Value Type of the collection data
+ * @param {Query<Value> | undefined | null} query Firestore query that will be fetched
+ * @param {?UseQueryDataOnceOptions} options Options to configure how the query is fetched
+ * @returns {UseQueryDataOnceResult<Value>} Query data, loading state, and error
+ * * value: Query data; `undefined` if query is currently being fetched, or an error occurred
+ * * loading: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
+ * * error: `undefined` if no error occurred
+ */
+export function useQueryDataOnce<Value extends DocumentData = DocumentData>(
+    query: Query<Value> | undefined | null,
+    options?: UseQueryDataOnceOptions
+): UseQueryDataOnceResult<Value> {
+    const { source = "default", snapshotOptions = {} } = options ?? {};
+
+    const getData = useCallback(async (stableQuery: Query<Value>) => {
+        const snap = await getDocsFromSource(stableQuery, source);
+        return snap.docs.map((doc) => doc.data(snapshotOptions));
+    }, []);
+    return useOnce(query ?? undefined, getData, isQueryEqual);
+}

--- a/src/firestore/useQueryOnce.ts
+++ b/src/firestore/useQueryOnce.ts
@@ -1,0 +1,39 @@
+import { DocumentData, FirestoreError, Query, QuerySnapshot } from "firebase/firestore";
+import { useCallback } from "react";
+import type { ValueHookResult } from "../common/types.js";
+import { useOnce } from "../internal/useOnce.js";
+import { getDocsFromSource, isQueryEqual } from "./internal.js";
+import type { Source } from "./types.js";
+
+export type UseQueryOnceResult<Value extends DocumentData = DocumentData> = ValueHookResult<
+    QuerySnapshot<Value>,
+    FirestoreError
+>;
+
+/**
+ * Options to configure how the query is fetched
+ */
+export interface UseQueryOnceOptions {
+    source?: Source;
+}
+
+/**
+ * Returns the QuerySnapshot of a Firestore Query. Does not update the QuerySnapshot once initially fetched
+ *
+ * @template Value Type of the collection data
+ * @param {Query<Value> | undefined | null} query Firestore query that will be fetched
+ * @param {?UseQueryOnceOptions} options Options to configure how the query is fetched
+ * @returns {UseQueryOnceResult<Value>} QuerySnapshot, loading state, and error
+ * * value: QuerySnapshot; `undefined` if query is currently being fetched, or an error occurred
+ * * loading: `true` while fetching the query; `false` if the query was fetched successfully or an error occurred
+ * * error: `undefined` if no error occurred
+ */
+export function useQueryOnce<Value extends DocumentData = DocumentData>(
+    query: Query<Value> | undefined | null,
+    options?: UseQueryOnceOptions
+): UseQueryOnceResult<Value> {
+    const { source = "default" } = options ?? {};
+
+    const getData = useCallback(async (stableQuery: Query<Value>) => getDocsFromSource(stableQuery, source), []);
+    return useOnce(query ?? undefined, getData, isQueryEqual);
+}


### PR DESCRIPTION
Existing hooks are deprecated and will be removed with
the next major version update
